### PR TITLE
Add option to specify absolute start time

### DIFF
--- a/cmd/glucose/main.go
+++ b/cmd/glucose/main.go
@@ -21,6 +21,7 @@ const (
 var (
 	all      = flag.Bool("a", false, "get all records")
 	duration = flag.Duration("d", time.Hour, "get `duration` worth of previous records")
+	sinceFlag = flag.String("t", "", "get records since the specified `time` in RFC3339 format")
 	format   = flag.String("f", textFormat, "format in which to print records (csv, json, ns, or text)")
 
 	egv         = flag.Bool("e", true, "include EGV records")
@@ -58,6 +59,13 @@ func main() {
 		*sensor = true
 		*calibration = true
 		*meter = true
+	} else if *sinceFlag != "" {
+		var err error
+		cutoff, err = time.Parse(dexcom.JSONTimeLayout, *sinceFlag)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			os.Exit(1)
+		}
 	} else {
 		cutoff = time.Now().Add(-*duration)
 		log.Printf("retrieving records since %s", cutoff.Format(dexcom.UserTimeLayout))

--- a/time.go
+++ b/time.go
@@ -5,6 +5,8 @@ import (
 )
 
 const (
+	// JSONTimeLayout specifies the format for JSON time values.
+	JSONTimeLayout = time.RFC3339
 	// UserTimeLayout specifies a consistent, human-readable format for local time.
 	UserTimeLayout = "2006-01-02 15:04:05"
 )


### PR DESCRIPTION
This mirrors the `sinceFlag` option in the `pumphistory` command, to allow us to pull only the records written since the last successful pull.